### PR TITLE
test: validate `addresses` response body structure

### DIFF
--- a/api-tests/src/test/kotlin/com/envylabs/cautiousengine/api/AddressesTest.kt
+++ b/api-tests/src/test/kotlin/com/envylabs/cautiousengine/api/AddressesTest.kt
@@ -1,5 +1,6 @@
 package com.envylabs.cautiousengine.api
 
+import com.envylabs.cautiousengine.helpers.AddressValidationHelper
 import com.envylabs.cautiousengine.helpers.TestConstants
 import io.restassured.http.ContentType
 import io.restassured.module.kotlin.extensions.Given
@@ -26,10 +27,12 @@ class AddressesTest {
                 statusCode(200)
                 body("addresses", CoreMatchers.isA(List::class.java))
                 body("addresses", Matchers.notNullValue())
-                body("addresses.size()", Matchers.greaterThanOrEqualTo(0))
+                body("addresses.size()", Matchers.greaterThanOrEqualTo(1))
                 body("addresses.size()", Matchers.lessThanOrEqualTo(100))
                 body("count", CoreMatchers.isA(Int::class.java))
                 body("count", Matchers.notNullValue())
+
+                AddressValidationHelper.validateAddressesBodyArrayElement(this)
             }
         }
     }
@@ -46,20 +49,7 @@ class AddressesTest {
                 get("${TestConstants.BASE_URL}/addresses/a1b2c3")
             } Then {
                 statusCode(200)
-                body("street", CoreMatchers.isA(String::class.java))
-                body("street", Matchers.notNullValue())
-
-                body("city", CoreMatchers.isA(String::class.java))
-                body("city", Matchers.notNullValue())
-
-                body("state", CoreMatchers.isA(String::class.java))
-                body("state", Matchers.notNullValue())
-
-                body("zipCode", CoreMatchers.isA(String::class.java))
-                body("zipCode", Matchers.notNullValue())
-
-                body("createdAt", CoreMatchers.isA(String::class.java))
-                body("createdAt", Matchers.notNullValue())
+                AddressValidationHelper.validateAddressBody(this)
             }
         }
     }

--- a/api-tests/src/test/kotlin/com/envylabs/cautiousengine/helpers/AddressValidationHelper.kt
+++ b/api-tests/src/test/kotlin/com/envylabs/cautiousengine/helpers/AddressValidationHelper.kt
@@ -1,0 +1,42 @@
+package com.envylabs.cautiousengine.helpers
+
+import io.restassured.response.ValidatableResponse
+import org.hamcrest.CoreMatchers
+import org.hamcrest.Matchers
+
+object AddressValidationHelper {
+
+    fun validateAddressBody(vr: ValidatableResponse) {
+        vr.body("street", CoreMatchers.isA(String::class.java))
+        vr.body("street", Matchers.notNullValue())
+
+        vr.body("city", CoreMatchers.isA(String::class.java))
+        vr.body("city", Matchers.notNullValue())
+
+        vr.body("state", CoreMatchers.isA(String::class.java))
+        vr.body("state", Matchers.notNullValue())
+
+        vr.body("zipCode", CoreMatchers.isA(String::class.java))
+        vr.body("zipCode", Matchers.notNullValue())
+
+        vr.body("createdAt", CoreMatchers.isA(String::class.java))
+        vr.body("createdAt", Matchers.notNullValue())
+    }
+
+    fun validateAddressesBodyArrayElement(vr: ValidatableResponse, element: Int = 0) {
+        vr.body("addresses[$element].street", CoreMatchers.isA(String::class.java))
+        vr.body("addresses[$element].street", Matchers.notNullValue())
+
+        vr.body("addresses[$element].city", CoreMatchers.isA(String::class.java))
+        vr.body("addresses[$element].city", Matchers.notNullValue())
+
+        vr.body("addresses[$element].state", CoreMatchers.isA(String::class.java))
+        vr.body("addresses[$element].state", Matchers.notNullValue())
+
+        vr.body("addresses[$element].zipCode", CoreMatchers.isA(String::class.java))
+        vr.body("addresses[$element].zipCode", Matchers.notNullValue())
+
+        vr.body("addresses[$element].createdAt", CoreMatchers.isA(String::class.java))
+        vr.body("addresses[$element].createdAt", Matchers.notNullValue())
+    }
+}


### PR DESCRIPTION
This commit adds validation of the structure of the first `address` element in
the response body returned by `/addresses`.