### PR TITLE
fix: enable custom Jackson `ObjectMapper` config

### DIFF
--- a/spring-boot_postgres/src/main/kotlin/com/envylabs/cautiousengine/config/JacksonConfig.kt
+++ b/spring-boot_postgres/src/main/kotlin/com/envylabs/cautiousengine/config/JacksonConfig.kt
@@ -6,11 +6,13 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 class JacksonConfig {
 
+    @Bean
     fun objectMapper(): ObjectMapper {
         return ObjectMapper().apply {
             this.propertyNamingStrategy = PropertyNamingStrategy.SNAKE_CASE


### PR DESCRIPTION
This commit resolves an issue by adding the `@Bean` annotation to the custom
Jackson `ObjectMapper` configuration. The missing annotation was causing Spring
to use its default `ObjectMapper` implementation.