### PR TITLE
doc: better credit to original authors

### DIFF
--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -1,0 +1,1 @@
+These load tests are based off of the [Micronaut Comparisons repo](https://github.com/micronaut-projects/micronaut-comparisons)

--- a/load-tests/src/gatling/simulations/com/envylabs/cautiousengine/CautiousEngineSimulation.scala
+++ b/load-tests/src/gatling/simulations/com/envylabs/cautiousengine/CautiousEngineSimulation.scala
@@ -6,6 +6,15 @@ import io.gatling.http.Predef._
 import scala.concurrent.duration._
 import scala.util.Random
 
+/**
+ * This is a slightly modified version of the JHipster simulation from the Micronaut comparisons repo.
+ *
+ * Micronaut Comparisons Repo
+ * https://github.com/micronaut-projects/micronaut-comparisons
+ *
+ * Original Simulation
+ * https://github.com/micronaut-projects/micronaut-comparisons/blob/master/loadtests/src/gatling/simulations/com/example/JHipsterSimulation.scala
+ */
 class CautiousEngineSimulation extends Simulation {
   val httpConf = http
     .baseUrl(baseUrl)


### PR DESCRIPTION
This commit better documents the [Micronaut Comparisons repo](https://github.com/micronaut-projects/micronaut-comparisons) as the source of the initial load tests.