### PR TITLE
performance adjustments and other cleanup

### DIFF
--- a/load-tests/src/gatling/resources/logback.xml
+++ b/load-tests/src/gatling/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="warn">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/load-tests/src/gatling/simulations/com/envylabs/cautiousengine/CautiousEngineSimulation.scala
+++ b/load-tests/src/gatling/simulations/com/envylabs/cautiousengine/CautiousEngineSimulation.scala
@@ -3,6 +3,7 @@ package com.envylabs.cautiousengine
 import io.gatling.core.Predef.{exec, _}
 import io.gatling.http.Predef._
 
+import java.util.UUID
 import scala.concurrent.duration._
 import scala.util.Random
 
@@ -51,7 +52,7 @@ class CautiousEngineSimulation extends Simulation {
 
   def getAddress() = {
     exec(http("address")
-      .get("/addresses/" + Random.nextInt())
+      .get("/addresses/" + UUID.randomUUID())
       .check(status.is(200)))
   }
 

--- a/micronaut_postgres/src/main/kotlin/com/envylabs/cautiousengine/services/AddressService.kt
+++ b/micronaut_postgres/src/main/kotlin/com/envylabs/cautiousengine/services/AddressService.kt
@@ -3,6 +3,6 @@ package com.envylabs.cautiousengine.services
 import com.envylabs.cautiousengine.models.Address
 
 interface AddressService {
-    fun many(limit: Int = 100): List<Address>
+    fun many(limit: Int = 10): List<Address>
     fun one(): Address
 }

--- a/spring-boot_postgres/src/main/kotlin/com/envylabs/cautiousengine/services/AddressService.kt
+++ b/spring-boot_postgres/src/main/kotlin/com/envylabs/cautiousengine/services/AddressService.kt
@@ -3,6 +3,6 @@ package com.envylabs.cautiousengine.services
 import com.envylabs.cautiousengine.models.Address
 
 interface AddressService {
-    fun many(limit: Int = 100): List<Address>
+    fun many(limit: Int = 10): List<Address>
     fun one(): Address
 }


### PR DESCRIPTION
This change contains the following changes
- lower the max number of results returned by `/addresses` from 100
to 10. A max of 100 was creating unrealistic memory requirements for the load
tests running with 1,000 concurrent users.
- change load tests logging level to `warn`
- use random uuid for /address/{id} requests